### PR TITLE
fixed #2247: Using functions instead of macros to speeding up building for JSB projects.

### DIFF
--- a/targets/spidermonkey/conversions.yaml
+++ b/targets/spidermonkey/conversions.yaml
@@ -42,7 +42,7 @@ conversions:
       do {
       ${($level + 1) * '\t'}js_proxy_t *proxy;
       ${($level + 1) * '\t'}JSObject *tmpObj = JSVAL_TO_OBJECT(${in_value});
-      ${($level + 1) * '\t'}JS_GET_NATIVE_PROXY(proxy, tmpObj);
+      ${($level + 1) * '\t'}proxy = jsb_get_js_proxy(tmpObj);
       ${($level + 1) * '\t'}${out_value} = (${ntype})(proxy ? proxy->ptr : NULL);
       ${($level + 1) * '\t'}JSB_PRECONDITION2( ${out_value}, cx, JS_FALSE, "Invalid Native Object");
       ${($level + 0) * '\t'}} while (0)

--- a/targets/spidermonkey/templates/ifunction.c
+++ b/targets/spidermonkey/templates/ifunction.c
@@ -7,7 +7,7 @@ JSBool ${signature_name}(JSContext *cx, uint32_t argc, jsval *vp)
 #end if
 #if not $is_constructor
 	JSObject *obj = JS_THIS_OBJECT(cx, vp);
-	js_proxy_t *proxy; JS_GET_NATIVE_PROXY(proxy, obj);
+	js_proxy_t *proxy = jsb_get_js_proxy(obj);
 	${namespaced_class_name}* cobj = (${namespaced_class_name} *)(proxy ? proxy->ptr : NULL);
 	JSB_PRECONDITION2( cobj, cx, JS_FALSE, "Invalid Native Object");
 #end if
@@ -56,8 +56,7 @@ JSBool ${signature_name}(JSContext *cx, uint32_t argc, jsval *vp)
 		JSObject *obj = JS_NewObject(cx, typeClass->jsclass, typeClass->proto, typeClass->parentProto);
 		JS_SET_RVAL(cx, vp, OBJECT_TO_JSVAL(obj));
 		// link the native object with the javascript object
-		js_proxy_t *p;
-		JS_NEW_PROXY(p, cobj, obj);
+		js_proxy_t* p = jsb_new_proxy(cobj, obj);
 #if not $generator.script_control_cpp
 		JS_AddNamedObjectRoot(cx, &p->obj, "${namespaced_class_name}");
 #end if

--- a/targets/spidermonkey/templates/ifunction_overloaded.c
+++ b/targets/spidermonkey/templates/ifunction_overloaded.c
@@ -8,7 +8,7 @@ JSBool ${signature_name}(JSContext *cx, uint32_t argc, jsval *vp)
 	${namespaced_class_name}* cobj = NULL;
 #if not $is_constructor
 	obj = JS_THIS_OBJECT(cx, vp);
-	js_proxy_t *proxy; JS_GET_NATIVE_PROXY(proxy, obj);
+	js_proxy_t *proxy = jsb_get_js_proxy(obj);
 	cobj = (${namespaced_class_name} *)(proxy ? proxy->ptr : NULL);
 	JSB_PRECONDITION2( cobj, cx, JS_FALSE, "Invalid Native Object");
 #end if
@@ -54,8 +54,7 @@ JSBool ${signature_name}(JSContext *cx, uint32_t argc, jsval *vp)
 			HASH_FIND_INT(_js_global_type_ht, &typeId, typeClass);
 			assert(typeClass);
 			obj = JS_NewObject(cx, typeClass->jsclass, typeClass->proto, typeClass->parentProto);
-			js_proxy_t *proxy;
-			JS_NEW_PROXY(proxy, cobj, obj);
+			js_proxy_t* proxy = jsb_new_proxy(cobj, obj);
 #if not $generator.script_control_cpp
 			JS_AddNamedObjectRoot(cx, &proxy->obj, "${namespaced_class_name}");
 #end if

--- a/targets/spidermonkey/templates/layout_head.c
+++ b/targets/spidermonkey/templates/layout_head.c
@@ -19,8 +19,7 @@ static JSBool dummy_constructor(JSContext *cx, uint32_t argc, jsval *vp) {
 	HASH_FIND_INT(_js_global_type_ht, &typeId, p);
 	assert(p);
 	JSObject *_tmp = JS_NewObject(cx, p->jsclass, p->proto, p->parentProto);
-	js_proxy_t *pp;
-	JS_NEW_PROXY(pp, cobj, _tmp);
+	js_proxy_t *pp = jsb_new_proxy(cobj, _tmp);
 #if not $script_control_cpp
 	JS_AddObjectRoot(cx, &pp->obj);
 #end if

--- a/targets/spidermonkey/templates/register.c
+++ b/targets/spidermonkey/templates/register.c
@@ -17,15 +17,15 @@ void js_${generator.prefix}_${current_class.class_name}_finalize(JSFreeOp *fop, 
 #if $generator.script_control_cpp
     js_proxy_t* nproxy;
     js_proxy_t* jsproxy;
-    JS_GET_NATIVE_PROXY(jsproxy, obj);
+    jsproxy = jsb_get_js_proxy(obj);
     if (jsproxy) {
-        JS_GET_PROXY(nproxy, jsproxy->ptr);
+        nproxy = jsb_get_native_proxy(jsproxy->ptr);
 
         ${current_class.namespaced_class_name} *nobj = static_cast<${current_class.namespaced_class_name} *>(nproxy->ptr);
         if (nobj)
             delete nobj;
         
-        JS_REMOVE_PROXY(nproxy, jsproxy);
+        jsb_remove_proxy(nproxy, jsproxy);
     }
 #end if
 }
@@ -35,8 +35,7 @@ static JSBool js_${generator.prefix}_${current_class.class_name}_ctor(JSContext 
 {
 	JSObject *obj = JS_THIS_OBJECT(cx, vp);
     ${current_class.namespaced_class_name} *nobj = new ${current_class.namespaced_class_name}();
-    js_proxy_t* p;
-    JS_NEW_PROXY(p, nobj, obj);
+    js_proxy_t* p = jsb_new_proxy(nobj, obj);
 #if not $generator.script_control_cpp
     nobj->autorelease();
     JS_AddNamedObjectRoot(cx, &p->obj, "${current_class.namespaced_class_name}");


### PR DESCRIPTION
JS_NEW_PROXY --> jsb_new_proxy
JS_GET_PROXY --> jsb_get_native_proxy
JS_GET_NATIVE_PROXY --> jsb_get_js_proxy
JS_REMOVE_PROXY --> jsb_remove_proxy

Since the implementation of JS_XXX macros are using UTHASH which is also implemented by marcos totally,
it will expand `jsb_cocos2dx_auto.cpp` to a very huge state when compiling which makes the compilation very slow.
On android, just building _jsb_cocos2dx_auto.cpp_ and _jsb_cocos2dx_extension_auto.cpp_ will take _5 minutes_.
After these changes, it takes only _2 minutes_, it means that, we can save about more than half time than before.

The changes of Cocos2d-x is here (https://github.com/cocos2d/cocos2d-x/pull/2725).
