### PR TITLE
Indention fix for static and overload function and overload function fix

### DIFF
--- a/targets/spidermonkey/conversions.yaml
+++ b/targets/spidermonkey/conversions.yaml
@@ -40,6 +40,7 @@ conversions:
     "ccFontDefinition":  "ok &= jsval_to_ccfontdefinition(cx, ${in_value}, &${out_value})"
     object: |
       do {
+      ${($level + 1) * '\t'}if (!${in_value}.isObject()) { ok = JS_FALSE; break; }
       ${($level + 1) * '\t'}js_proxy_t *proxy;
       ${($level + 1) * '\t'}JSObject *tmpObj = JSVAL_TO_OBJECT(${in_value});
       ${($level + 1) * '\t'}proxy = jsb_get_js_proxy(tmpObj);

--- a/targets/spidermonkey/templates/sfunction_overloaded.c
+++ b/targets/spidermonkey/templates/sfunction_overloaded.c
@@ -21,7 +21,7 @@ JSBool ${signature_name}(JSContext *cx, uint32_t argc, jsval *vp)
 							 "in_value": "argv[" + str(count) + "]",
 							 "out_value": "arg" + str(count),
 							 "class_name": $class_name,
-							 "level": 2,
+							 "level": 3,
 							 "ntype": str($arg)})};
 			#set $arg_array += ["arg"+str(count)]
 			#set $count = $count + 1


### PR DESCRIPTION
In overloaded function, if there are the same arguments but with one or more different type. 'If else' may fails since String can't be converted to Object by JSVAL_TO_OBJECT. So we need to check whether the jsval is an object. If not, break with 'ok = JS_FALSE'.

``` cpp
e.g. cc.MotionStreak.create(2, 3, 32, cc.GREEN, string); // here, 'string' isn't an object, so the binding glue codes will crash in JSVAL_TO_OBJECT
       cc.MotionStreak.create(2, 3, 32, cc.GREEN, texture);
```
