### PR TITLE
Generate conversion from JS functions to std::function.

### DIFF
--- a/targets/spidermonkey/templates/lambda.c
+++ b/targets/spidermonkey/templates/lambda.c
@@ -1,0 +1,33 @@
+do {
+	std::shared_ptr<JSFunctionWrapper> func(new JSFunctionWrapper(cx, JS_THIS_OBJECT(cx, vp), ${in_value}));
+	auto lambda = [=](${lambda_parameters}) -> ${ret_type.name} {
+		#set arg_count = len($param_types)
+		jsval largv[${arg_count}];
+		#set $count = 0
+		#while $count < $arg_count
+			#set $arg = $param_types[$count]
+		${arg.from_native({"generator": $generator,
+							 "in_value": "larg" + str(count),
+							 "out_value": "largv[" + str(count) + "]",
+							 "class_name": $class_name,
+							 "level": 2,
+							 "ntype": str($arg)})};
+			#set $count = $count + 1
+		#end while
+		jsval rval;
+		JSBool ok = func->invoke(${arg_count}, &largv[0], rval);
+		if (!ok && JS_IsExceptionPending(cx)) {
+			JS_ReportPendingException(cx);
+		}
+		#if $ret_type.name != "void"
+		${ret_type} ret;
+		${ret_type.to_native({"generator": $generator,
+							 "in_value": "rval",
+							 "out_value": "ret",
+							 "ntype": str($ret_type),
+							 "level": 2})};
+		return ret;
+		#end if
+	};
+	${out_value} = lambda;
+} while(0)


### PR DESCRIPTION
This patch generates binding code for C++ methods that contains std::function parameters.  This depends on an implementation of "JSFunctionWrapper", which is added to cocos2d-x in another pull-request.

Unfortunately, libclang doesn't give structured type information for template arguments, so this binding code will not work for some complex arguments. For example, it won't generate binding code for a std::function that contains std::functions as parameters or return values.  It will work for most simple arguments: void, int, Dictionary*, objects, etc.

For example for:

class Foo {
    static void addHandler(const std::function<void ()> handler);
};

This would generate something like:

do {
  std::shared_ptr<JSFunctionWrapper> func(new JSFunctionWrapper(cx, JS_THIS_OBJECT(cx, vp), argv[0]));
  auto lambda = [=]() -> void {
    jsval largv[0];
    jsval rval;
    JSBool ok = func->invoke(0, &largv[0], rval);
    if (!ok && JS_IsExceptionPending(cx)) {
      JS_ReportPendingException(cx);
    }
  };
  arg0 = lambda;
} while(0)
;
