### PR TITLE
Don't set a default PYTHON_ROOT & NDK_ROOT for user on Windows

### DIFF
--- a/test/test.bat
+++ b/test/test.bat
@@ -1,11 +1,12 @@
 @echo off
 
 :: This script is used to generate jsbinding glue codes.
+:: Android ndk version must be ndk-r9b.
 :: You should modify PYTHON_ROOT and NDK_ROOT to work under your environment.
-:: Android ndk version must be at least ndk-r9b.
+:: or just uncomment the follow 2 lines and set them.
 
-set PYTHON_ROOT=C:/Python27
-set NDK_ROOT=G:/android/android-ndk-r9b
+:: set PYTHON_ROOT=C:/Python27
+:: set NDK_ROOT=G:/android/android-ndk-r9b
 set CLANG_ROOT=%NDK_ROOT%/toolchains/llvm-3.3/prebuilt/windows-x86_64
 
 set CXX_GENERATOR_ROOT=%cd%/..

--- a/test/test.bat
+++ b/test/test.bat
@@ -2,11 +2,28 @@
 
 :: This script is used to generate jsbinding glue codes.
 :: Android ndk version must be ndk-r9b.
+
+setlocal
 :: You should modify PYTHON_ROOT and NDK_ROOT to work under your environment.
 :: or just uncomment the follow 2 lines and set them.
 
 :: set PYTHON_ROOT=C:/Python27
 :: set NDK_ROOT=G:/android/android-ndk-r9b
+
+setlocal ENABLEEXTENSIONS
+if %errorlevel% neq 0 (
+    echo Unable to enable extensions
+    goto QUIT
+    )
+
+if defined PYTHON_ROOT (echo PYTHON_ROOT is defined.) else (
+    echo PYTHON_ROOT is NOT defined!
+    goto QUIT)
+
+if defined NDK_ROOT (echo NDK_ROOT is defined.) else (
+    echo NDK_ROOT is NOT defined!
+    goto QUIT)
+
 set CLANG_ROOT=%NDK_ROOT%/toolchains/llvm-3.3/prebuilt/windows-x86_64
 
 set CXX_GENERATOR_ROOT=%cd%/..
@@ -55,8 +72,10 @@ goto QUIT
 echo ---------------------------------
 echo Generating bindings fails.
 echo ---------------------------------
+endlocal
 
 :QUIT
-
 pause
+endlocal
+
 


### PR DESCRIPTION
Don't set a default PYTHON_ROOT & NDK_ROOT for user on Windows.
