### PR TITLE
Add conversional config for Lua binding

### DIFF
--- a/targets/lua/conversions.yaml
+++ b/targets/lua/conversions.yaml
@@ -66,6 +66,7 @@ conversions:
     "@vector<int.*>": "ok &= luaval_to_std_vector_int(tolua_S, ${arg_idx}, &${out_value})"
     "kmMat4": "ok &= luaval_to_kmMat4(tolua_S, ${arg_idx}, &${out_value})"
     "Matrix": "ok &= luaval_to_matrix(tolua_S, ${arg_idx}, &${out_value})"
+    "_ttfConfig": "ok &= luaval_to_ttfconfig(tolua_S, ${arg_idx}, &${out_value})"
 
     object: "ok &= luaval_to_object<${arg.to_string($generator).replace(\"*\", \"\")}>(tolua_S, ${arg_idx}, \"${scriptname}\",&${out_value})"
   from_native:
@@ -110,5 +111,8 @@ conversions:
     "@vector<std::basic_string.*>": "ccvector_std_string_to_luaval(tolua_S, ${in_value})"
     "@vector<int.*>": "ccvector_int_to_luaval(tolua_S, ${in_value})"
     "Matrix": "matrix_to_luaval(tolua_S, ${in_value})"
+    "BlendFunc": "blendfunc_to_luaval(tolua_S, ${in_value})"
+    "_ttfConfig": "ttfconfig_to_luaval(tolua_S, ${in_value})"
+
     object: "object_to_luaval<${ntype.replace(\"*\", \"\").replace(\"const \", \"\")}>(tolua_S, \"${scriptname}\",(${ntype.replace(\"const \", \"\")})${in_value})"
 


### PR DESCRIPTION
Do I need to add `luaval_to_blendfunc`.Because the old version, all the `setBlendfunc` were bound to Lua by manaully and the number of parameter are two.
