### PR TITLE
fix a lambda bindings bug

### DIFF
--- a/targets/spidermonkey/conversions.yaml
+++ b/targets/spidermonkey/conversions.yaml
@@ -86,6 +86,7 @@ conversions:
     "unsigned char": "${out_value} = uint32_to_jsval(cx, ${in_value})"
     "long long": "${out_value} = long_long_to_jsval(cx, ${in_value})"
     "std::string": "${out_value} = std_string_to_jsval(cx, ${in_value})"
+    "basic_string<char>": "${out_value} = std_string_to_jsval(cx, ${in_value})"
     "char*": "${out_value} = c_string_to_jsval(cx, ${in_value})"
     bool: "${out_value} = BOOLEAN_TO_JSVAL(${in_value})"
     float: "${out_value} = DOUBLE_TO_JSVAL(${in_value})"


### PR DESCRIPTION
if a lambda has a std::string parameter, it will generate code like:

```
do {
      if (larg1) {
             js_proxy_t *jsProxy = js_get_or_create_proxy<std::basic_string<char>>(cx, std::basic_string<char>)larg1);
             largv[1] = OBJECT_TO_JSVAL(jsProxy->obj);
      } else {
             largv[1] = JSVAL_NULL;
      }
 } while (0)
```

the correct binding should be:

```
largv[1] = std_string_to_jsval(cx, larg1)
```
