### PR TITLE
fix std::function match for std::function<Ref *()>

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -241,7 +241,7 @@ class NativeType(object):
 
                 if nt.name == "std::function":
                     nt.namespaced_name = get_namespaced_name(cdecl)                    
-                    r = re.compile('function<(.+) .*\((.*)\)>').search(cdecl.displayname)
+                    r = re.compile('function<(.+) *\((.*)\)>').search(cdecl.displayname)
                     (ret_type, params) = r.groups()
                     params = filter(None, params.split(", "))
 


### PR DESCRIPTION
old regex:  `function<(.+) .*\((.*)\)>`
now regex: `function<(.+) *\((.*)\)>`

input string is `function<Ref *(void)>`
result about first group:
old:  `Ref`
now:  `Ref *`
