### PR TITLE
Tip opt

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -457,6 +457,7 @@ class NativeFunction(object):
         self.is_override = False
         self.ret_type = NativeType.from_type(cursor.result_type)
         self.comment = self.get_comment(cursor.getRawComment())
+        self.func_desc = ""
 
         # parse the arguments
         # if self.func_name == "spriteWithFile":
@@ -513,9 +514,32 @@ class NativeFunction(object):
 
         return replaceStr
 
+    def set_funtion_desc(self, generator):
+        if generator.script_type == "lua":
+            arg_count    = len(self.arguments)
+            arg_min_args = self.min_args
+            func_count   = 0
+            while arg_min_args <= arg_count:
+                arg_idx = 0
+                if func_count > 0:
+                    self.func_desc += " or "
+                self.func_desc +=  self.func_name + "("
+                while arg_idx < arg_min_args:
+                    arg = self.arguments[arg_idx]
+                    if arg_idx == arg_min_args - 1:
+                        self.func_desc +=  generator.lua_scriptname_tip_from_native(arg.namespaced_name, arg.namespace_name)
+                    else:
+                        self.func_desc +=  generator.lua_scriptname_tip_from_native(arg.namespaced_name, arg.namespace_name) + ", "
+                    arg_idx += 1
+
+                self.func_desc = self.func_desc + ")"
+                arg_min_args += 1
+                func_count   += 1
+
     def generate_code(self, current_class=None, generator=None, is_override=False):
         gen = current_class.generator if current_class else generator
         config = gen.config
+        self.set_funtion_desc(gen)
         tpl = Template(file=os.path.join(gen.target, "templates", "function.h"),
                         searchList=[current_class, self])
         if not is_override:
@@ -568,6 +592,7 @@ class NativeOverloadedFunction(object):
             self.min_args = min(self.min_args, m.min_args)
 
         self.comment = self.get_comment(func_array[0].cursor.getRawComment())
+        self.func_descs = ""
 
     def get_comment(self, comment):
         replaceStr = comment
@@ -596,6 +621,30 @@ class NativeOverloadedFunction(object):
 
         return replaceStr
 
+    def set_funtion_desc(self, generator):
+        if generator.script_type == "lua":
+            func_count = 0
+            for func in self.implementations:
+                arg_count = len(func.arguments)
+                arg_min_args = func.min_args
+                while arg_min_args <= arg_count:
+                    arg_idx = 0
+                    if func_count > 0:
+                        self.func_descs += " or "
+                    self.func_descs += self.func_name + "("
+                    while arg_idx < arg_min_args:
+                        arg = func.arguments[arg_idx]
+                        if arg_idx == arg_min_args - 1:
+                            self.func_descs +=  generator.lua_scriptname_tip_from_native(arg.namespaced_name, arg.namespace_name)
+                        else:
+                            self.func_descs +=  generator.lua_scriptname_tip_from_native(arg.namespaced_name, arg.namespace_name) + ", "
+                        arg_idx += 1
+
+                    self.func_descs = self.func_descs + ")"
+                    arg_min_args += 1
+                    func_count   += 1
+                
+
     def append(self, func):
         self.min_args = min(self.min_args, func.min_args)
         self.implementations.append(func)
@@ -603,6 +652,7 @@ class NativeOverloadedFunction(object):
     def generate_code(self, current_class=None, is_override=False):
         gen = current_class.generator
         config = gen.config
+        self.set_funtion_desc(gen)
         static = self.implementations[0].static
         tpl = Template(file=os.path.join(gen.target, "templates", "function.h"),
                         searchList=[current_class, self])
@@ -1302,6 +1352,28 @@ class Generator(object):
             return "func"
         else:
             return namespace_class_name
+
+    def lua_scriptname_tip_from_native(self, namespace_class_name, namespace_name):
+        script_ns_dict = self.config['conversions']['ns_map']
+        for (k, v) in script_ns_dict.items():
+            if k == namespace_name:
+                return namespace_class_name.replace("*","").replace("const ", "").replace(k, v)
+        if namespace_class_name.find("::") >= 0:
+            if namespace_class_name.find("std::vector") == 0:
+                return "array_table"
+            elif namespace_class_name.find("std::unordered_map") == 0 or namespace_class_name.find("std::map") == 0:
+                return "map_table"
+            elif namespace_class_name.find("std::function") == 0:
+                return "function"
+            elif namespace_class_name.find("std::string") == 0:
+                return "string"
+            elif namespace_class_name.find("std::") == 0:
+                return namespace_class_name
+            else:
+                raise Exception("The namespace (%s) conversion wasn't set in 'ns_map' section of the conversions.yaml" % namespace_class_name)
+        else:
+            return namespace_class_name.replace("*","").replace("const ", "")
+
 def main():
     from optparse import OptionParser
 

--- a/targets/lua/templates/ifunction.c
+++ b/targets/lua/templates/ifunction.c
@@ -106,7 +106,7 @@ int ${signature_name}(lua_State* tolua_S)
         #set $arg_idx = $arg_idx + 1
     #end while
 #end if
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d ,the layout of the parameters are as follows:%s \n", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func_name}",argc, ${min_args}, "$func_desc");
+    CCLOG("%s has wrong number of arguments: %d, the minimum number expected is %d ,the layout of the parameters are as follows:%s \n", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func_name}",argc, ${min_args}, "$func_desc");
     return 0;
 
 \#if COCOS2D_DEBUG >= 1

--- a/targets/lua/templates/ifunction.c
+++ b/targets/lua/templates/ifunction.c
@@ -106,7 +106,7 @@ int ${signature_name}(lua_State* tolua_S)
         #set $arg_idx = $arg_idx + 1
     #end while
 #end if
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func_name}",argc, ${min_args});
+    CCLOG("%s has wrong number of arguments: %d, was expecting %d ,the layout of the parameters are as follows:%s \n", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func_name}",argc, ${min_args}, "$func_desc");
     return 0;
 
 \#if COCOS2D_DEBUG >= 1

--- a/targets/lua/templates/ifunction_overloaded.c
+++ b/targets/lua/templates/ifunction_overloaded.c
@@ -101,7 +101,7 @@ int ${signature_name}(lua_State* tolua_S)
     #end while
 #end if
 #end for
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n",  "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func.func_name}",argc, ${func.min_args});
+    CCLOG("%s has wrong number of arguments: %d, was expecting %d, the layout of the parameters are as follows:%s \n",  "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func.func_name}",argc, ${func.min_args}, "$func_descs");
     return 0;
 
 \#if COCOS2D_DEBUG >= 1

--- a/targets/lua/templates/ifunction_overloaded.c
+++ b/targets/lua/templates/ifunction_overloaded.c
@@ -101,7 +101,7 @@ int ${signature_name}(lua_State* tolua_S)
     #end while
 #end if
 #end for
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d, the layout of the parameters are as follows:%s \n",  "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func.func_name}",argc, ${func.min_args}, "$func_descs");
+    CCLOG("%s has wrong number of arguments: %d, the minimum number expected is %d, the layout of the parameters are as follows:%s \n",  "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func.func_name}",argc, ${func.min_args}, "$func_descs");
     return 0;
 
 \#if COCOS2D_DEBUG >= 1

--- a/targets/lua/templates/sfunction.c
+++ b/targets/lua/templates/sfunction.c
@@ -73,7 +73,7 @@ int ${signature_name}(lua_State* tolua_S)
         #set $arg_idx = $arg_idx + 1
     #end while
 #end if
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d, the layout of the parameters are as follows:%s \n ", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func_name}",argc, ${min_args}, "$func_desc");
+    CCLOG("%s has wrong number of arguments: %d, the minimum number expected is %d, the layout of the parameters are as follows:%s \n ", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func_name}",argc, ${min_args}, "$func_desc");
     return 0;
 \#if COCOS2D_DEBUG >= 1
     tolua_lerror:

--- a/targets/lua/templates/sfunction.c
+++ b/targets/lua/templates/sfunction.c
@@ -73,7 +73,7 @@ int ${signature_name}(lua_State* tolua_S)
         #set $arg_idx = $arg_idx + 1
     #end while
 #end if
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func_name}",argc, ${min_args});
+    CCLOG("%s has wrong number of arguments: %d, was expecting %d, the layout of the parameters are as follows:%s \n ", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func_name}",argc, ${min_args}, "$func_desc");
     return 0;
 \#if COCOS2D_DEBUG >= 1
     tolua_lerror:

--- a/targets/lua/templates/sfunction_overloaded.c
+++ b/targets/lua/templates/sfunction_overloaded.c
@@ -72,7 +72,7 @@ int ${signature_name}(lua_State* tolua_S)
     #end while
     #end if
     #end for
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d,the layout of the parameters are as follows:%s \n", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func.func_name}",argc, ${func.min_args}, "$func_descs");
+    CCLOG("%s has wrong number of arguments: %d, the minimum number expected is %d,the layout of the parameters are as follows:%s \n", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func.func_name}",argc, ${func.min_args}, "$func_descs");
     return 0;
 \#if COCOS2D_DEBUG >= 1
     tolua_lerror:

--- a/targets/lua/templates/sfunction_overloaded.c
+++ b/targets/lua/templates/sfunction_overloaded.c
@@ -72,7 +72,7 @@ int ${signature_name}(lua_State* tolua_S)
     #end while
     #end if
     #end for
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func.func_name}",argc, ${func.min_args});
+    CCLOG("%s has wrong number of arguments: %d, was expecting %d,the layout of the parameters are as follows:%s \n", "${generator.scriptname_from_native($namespaced_class_name, $namespace_name)}:${func.func_name}",argc, ${func.min_args}, "$func_descs");
     return 0;
 \#if COCOS2D_DEBUG >= 1
     tolua_lerror:


### PR DESCRIPTION
1.For functions that have not overload and not params that have default values,the error tip is  "ccui.ScrollView:setInnerContainerSize has wrong number of arguments: 2, the minimum number expected is 1 ,the layout of the parameters are as follows:setInnerContainerSize(cc.Size)"
2.For functions that have not overload and have params that have default values,the error tip is
" cc.FileUtils:addSearchPat has wrong number of arguments: 3, the minimum number expected is 1 ,the layout of the parameters are as follows:addSearchPath(string) or addSearchPath(string, bool)")"
3.For functions that have overload,the error tip is "cc.Node:addChild has wrong number of arguments:4, the minimum number expected is 2, the layout of the parameters are as follows:addChild(cc.Node, int) or addChild(cc.Node) or addChild(cc.Node, int, int) or addChild(cc.Node, int, string)"
