### PR TITLE
Linux compilation fix

### DIFF
--- a/test/simple_test/simple_class.h
+++ b/test/simple_test/simple_class.h
@@ -3,6 +3,8 @@
 
 #include <string>
 #include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
 enum someThingEnumerated {
 	kValue1 = 1,


### PR DESCRIPTION
Some missing include in simple_class.h makes compilation fail on linux (I use a Fedora 20 64bits). This PR fixes this.

```
[100%] Building CXX object CMakeFiles/MyGame.dir/frameworks/runtime-src/Classes/simple_test/simple_class.cpp.o
/home/azmeuk/dev/mars/mars/frameworks/runtime-src/Classes/simple_test/simple_class.cpp: In member function ‘void SimpleNativeClass::setAnotherMoreComplexField(const char*)’:
/home/azmeuk/dev/mars/mars/frameworks/runtime-src/Classes/simple_test/simple_class.cpp:59:25: erreur: ‘strlen’ was not declared in this scope
  size_t len = strlen(str);
                         ^
/home/azmeuk/dev/mars/mars/frameworks/runtime-src/Classes/simple_test/simple_class.cpp:61:44: erreur: ‘memcpy’ was not declared in this scope
  memcpy(m_anotherMoreComplexField, str, len);
                                            ^
make[2]: *** [CMakeFiles/MyGame.dir/frameworks/runtime-src/Classes/simple_test/simple_class.cpp.o] Erreur 1
make[1]: *** [CMakeFiles/MyGame.dir/all] Erreur 2
make: *** [all] Erreur 
```
