### PR TITLE
Fix spelling mistake: ResouceData => ResourceData

### DIFF
--- a/targets/spidermonkey/conversions.yaml
+++ b/targets/spidermonkey/conversions.yaml
@@ -79,7 +79,7 @@ conversions:
     "TerrainData": "ok &= jsval_to_TerrainData(cx, ${in_value}, &${out_value})"
     "TMXTileFlags_": "ok &= jsval_to_uint32(cx, ${in_value}, (uint32_t *)&${out_value})"
     "TMXTileFlags_*": "uint32_t tempData;${out_value}=(cocos2d::TMXTileFlags_*)&tempData;ok &= jsval_to_uint32(cx, ${in_value}, (uint32_t *)&${out_value})"
-    "ResouceData": "ok &= jsval_to_resoucedata(cx, ${in_value}, &${out_value})"
+    "ResourceData": "ok &= jsval_to_resourcedata(cx, ${in_value}, &${out_value})"
     object: |
       do {
       ${($level + 1) * '    '}if (${in_value}.isNull()) { ${out_value} = nullptr; break; }
@@ -149,7 +149,7 @@ conversions:
     "Quaternion": "${out_value} = quaternion_to_jsval(cx, ${in_value})"
     "OffMeshLinkData": "${out_value} = offMeshLinkData_to_jsval(cx, ${in_value})"
     "Uniform*": "${out_value} = uniform_to_jsval(cx, ${in_value})"
-    "ResouceData": "${out_value} = resoucedata_to_jsval(cx, ${in_value})"
+    "ResourceData": "${out_value} = resourcedata_to_jsval(cx, ${in_value})"
     "TouchEventType": "${out_value} = int32_to_jsval(cx, (int)${in_value})"
     "EventType": "${out_value} = int32_to_jsval(cx, (int)${in_value})"
     object: |


### PR DESCRIPTION
Hi, this commit fixes small spelling mistake in v3.10.
Related to https://github.com/cocos2d/cocos2d-x/pull/14597.
