### PR TITLE
include cocos headers with path rooted form cocos directory.

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -975,6 +975,7 @@ class Generator(object):
     def __init__(self, opts):
         self.index = cindex.Index.create()
         self.outdir = opts['outdir']
+        self.search_path = opts['search_path']
         self.prefix = opts['prefix']
         self.headers = opts['headers'].split(' ')
         self.classes = opts['classes']
@@ -1524,6 +1525,7 @@ def main():
                 'clang_args': (config.get(s, 'extra_arguments', 0, dict(userconfig.items('DEFAULT'))) or "").split(" "),
                 'target': os.path.join(workingdir, "targets", t),
                 'outdir': outdir,
+                'search_path': os.path.join(userconfig.get('DEFAULT', 'cocosdir'), 'cocos'),
                 'remove_prefix': config.get(s, 'remove_prefix'),
                 'target_ns': config.get(s, 'target_namespace'),
                 'cpp_ns': config.get(s, 'cpp_namespace').split(' ') if config.has_option(s, 'cpp_namespace') else None,

--- a/targets/lua/templates/layout_head.c
+++ b/targets/lua/templates/layout_head.c
@@ -1,15 +1,18 @@
-\#include "${out_file}.hpp"
+\#include "scripting/lua-bindings/auto/${out_file}.hpp"
 #if $macro_judgement
 $macro_judgement
-#end if 
+#end if
 #for header in $headers
+    #if os.path.samefile(os.path.commonprefix([header, $search_path]), $search_path)
+\#include "${os.path.relpath(header, $search_path).replace(os.path.sep, '/')}"
+    #else
 \#include "${os.path.basename(header)}"
+    #end if
 #end for
-\#include "tolua_fix.h"
-\#include "LuaBasicConversions.h"
+\#include "scripting/lua-bindings/manual/tolua_fix.h"
+\#include "scripting/lua-bindings/manual/LuaBasicConversions.h"
 #if $cpp_headers
 #for header in $cpp_headers
 \#include "${header}"
 #end for
-#end if 
-
+#end if

--- a/targets/spidermonkey/templates/layout_head.c
+++ b/targets/spidermonkey/templates/layout_head.c
@@ -1,14 +1,18 @@
-\#include "${out_file}.hpp"
+\#include "scripting/js-bindings/auto/${out_file}.hpp"
 #if $macro_judgement
 $macro_judgement
-#end if 
-\#include "cocos2d_specifics.hpp"
+#end if
+\#include "scripting/js-bindings/manual/cocos2d_specifics.hpp"
 #for header in $headers
     #set include_header = os.path.basename(header)
     #if $replace_headers.has_key(include_header)
 \#include "${replace_headers[include_header]}"
     #else
+        #if os.path.samefile(os.path.commonprefix([header, $search_path]), $search_path)
+\#include "${os.path.relpath(header, $search_path).replace(os.path.sep, '/')}"
+        #else
 \#include "${include_header}"
+        #end if
     #end if
 #end for
 #if $cpp_headers


### PR DESCRIPTION
As cocos2d-x has now switch to use single include search path (the cocos2d-x/cocos directory) for all cocos headers.

We need binding generator to generate path relative to cocos2d-x/cocos directory.

Ref:

https://github.com/cocos2d/cocos2d-x/pull/15281
https://github.com/cocos2d/cocos2d-x/pull/15286
