### PR TITLE
Changes to the binding-generator to better leverage move semantics.

### DIFF
--- a/targets/lua/templates/ifunction.c
+++ b/targets/lua/templates/ifunction.c
@@ -56,7 +56,12 @@ int ${signature_name}(lua_State* tolua_S)
                                       "arg":$arg,
                                       "ntype": $arg.namespaced_name.replace("*", ""),
                                       "scriptname": $generator.scriptname_from_native($arg.namespaced_name, $arg.namespace_name)})};
-            #set $arg_array += ["arg"+str(count)]
+            #set arg_type = arg.to_string($generator)
+            #if arg.is_pointer or arg.is_numeric or arg.is_enum or arg_type == "bool"
+                #set $arg_array += ["arg"+str(count)]
+            #else
+                #set $arg_array += ["std::move(arg"+str(count)+")"]
+            #end if
             #set $count = $count + 1
         #end while
         #if $arg_idx >= 0

--- a/targets/lua/templates/sfunction.c
+++ b/targets/lua/templates/sfunction.c
@@ -42,7 +42,12 @@ int ${signature_name}(lua_State* tolua_S)
                          "arg":$arg,
                          "ntype": $arg.namespaced_name.replace("*", ""),
                          "scriptname": $generator.scriptname_from_native($arg.namespaced_name, $arg.namespace_name)})};
-                #set $arg_array += ["arg"+str($count)]
+                #set arg_type = arg.to_string($generator)
+                #if arg.is_pointer or arg.is_numeric or arg.is_enum or arg_type == "bool"
+                    #set $arg_array += ["arg"+str(count)]
+                #else
+                    #set $arg_array += ["std::move(arg"+str(count)+")"]
+                #end if
                 #set $count = $count + 1
         #end while
         #if $arg_idx >= 0

--- a/targets/spidermonkey/templates/ifunction.c
+++ b/targets/spidermonkey/templates/ifunction.c
@@ -39,7 +39,8 @@ bool ${signature_name}(JSContext *cx, uint32_t argc, jsval *vp)
                              "class_name": $class_name,
                              "level": 2,
                              "ntype": str($arg)})};
-            #if arg.is_pointer or arg.is_numeric
+            #set arg_type = arg.to_string($generator)
+            #if arg.is_pointer or arg.is_numeric or arg.is_enum or arg_type == "bool"
                 #set $arg_array += ["arg"+str(count)]
             #else
                 #set $arg_array += ["std::move(arg"+str(count)+")"]

--- a/targets/spidermonkey/templates/ifunction.c
+++ b/targets/spidermonkey/templates/ifunction.c
@@ -39,7 +39,11 @@ bool ${signature_name}(JSContext *cx, uint32_t argc, jsval *vp)
                              "class_name": $class_name,
                              "level": 2,
                              "ntype": str($arg)})};
-            #set $arg_array += ["arg"+str(count)]
+            #if arg.is_pointer or arg.is_numeric
+                #set $arg_array += ["arg"+str(count)]
+            #else
+                #set $arg_array += ["std::move(arg"+str(count)+")"]
+            #end if
             #set $count = $count + 1
         #end while
         #if $arg_idx > 0

--- a/targets/spidermonkey/templates/lambda.c
+++ b/targets/spidermonkey/templates/lambda.c
@@ -41,7 +41,7 @@ do {
             return ret;
             #end if
         };
-        ${out_value} = lambda;
+        ${out_value} = std::move(lambda);
     }
     else
     {

--- a/targets/spidermonkey/templates/sfunction.c
+++ b/targets/spidermonkey/templates/sfunction.c
@@ -33,7 +33,11 @@ bool ${signature_name}(JSContext *cx, uint32_t argc, jsval *vp)
             "class_name": $class_name,
             "level": 2,
             "ntype": str($arg)})};
-            #set $arg_array += ["arg"+str($count)]
+	    #if arg.is_numeric or arg.is_pointer
+                #set $arg_array += ["arg"+str($count)]
+            #else
+                #set $arg_array += ["std::move(arg"+str($count)+")"]
+            #end if
             #set $count = $count + 1
         #end while
         #if $arg_idx > 0

--- a/targets/spidermonkey/templates/sfunction.c
+++ b/targets/spidermonkey/templates/sfunction.c
@@ -33,7 +33,8 @@ bool ${signature_name}(JSContext *cx, uint32_t argc, jsval *vp)
             "class_name": $class_name,
             "level": 2,
             "ntype": str($arg)})};
-	    #if arg.is_numeric or arg.is_pointer
+            #set arg_type = arg.to_string($generator)
+            #if arg.is_pointer or arg.is_numeric or arg.is_enum or arg_type == "bool"
                 #set $arg_array += ["arg"+str($count)]
             #else
                 #set $arg_array += ["std::move(arg"+str($count)+")"]


### PR DESCRIPTION
The templates for the binding generator create temporary objects on the stack that are not std::moved into their proxy calls. This can cause unneeded copying for objects across the engine. In a better effort to have cocos2d-x better leverage move semantics, this PR updates the binding generator to better leverage move semantics by calling std::move on these temporary objects.  